### PR TITLE
Fix 'ISR not in IRAM' exception when attaching an interrupt

### DIFF
--- a/SonoffBoilerplate.ino
+++ b/SonoffBoilerplate.ino
@@ -175,7 +175,7 @@ void turnOff(int channel = 0) {
   setState(relayState, channel);
 }
 
-void toggleState() {
+ICACHE_RAM_ATTR void toggleState() {
   cmd = CMD_BUTTON_CHANGE;
 }
 
@@ -595,7 +595,3 @@ void loop()
 
 
 }
-
-
-
-


### PR DESCRIPTION
I believe it can fix #5 